### PR TITLE
Remvoe Avatar Url Column from Users Table

### DIFF
--- a/api/middleware/authentication.middleware.js
+++ b/api/middleware/authentication.middleware.js
@@ -3,10 +3,10 @@ const jwt = require('jsonwebtoken')
 const { v4: uuidv4 } = require('uuid')
 const UserModel = require('../models/user.model')
 
-const requiredUserInfo = ['username', 'email', 'password', 'avatar_url']
+const requiredRegisterInfo = ['username', 'email', 'password']
 
 const verifyUserRegisterBody = (req, res, next) => {
-  requiredUserInfo.forEach((property) => {
+  requiredRegisterInfo.forEach((property) => {
     if (!Object.prototype.hasOwnProperty.call(req.body, property)) {
       const error = new Error()
       error.message = `Missing Required user property: ${property}`
@@ -22,10 +22,7 @@ const verifyUserRegisterBody = (req, res, next) => {
 const hashPassword = async (req, res, next) => {
   if (res.locals.user) {
     try {
-      const hash = await bcrypt.hash(
-        res.locals.user.password,
-        Number(process.env.SALT)
-      )
+      const hash = await bcrypt.hash(res.locals.user.password, Number(process.env.SALT))
       if (hash !== res.locals.user.password) {
         res.locals.user.password = hash
         next()

--- a/api/models/user.model.js
+++ b/api/models/user.model.js
@@ -1,16 +1,10 @@
 const db = require('../../config/db')
 
-const getUserPassword = (filter) =>
-  db('users').where(filter).first().select('uuid', 'password')
+const getUserPassword = (filter) => db('users').where(filter).first().select('uuid', 'password')
 
-const getUserBy = (filter) =>
-  db('users')
-    .where(filter)
-    .first()
-    .select('uuid', 'username', 'avatar_url', 'public')
+const getUserBy = (filter) => db('users').where(filter).first().select('uuid', 'username', 'public')
 
-const getAllPublic = () =>
-  db('users').where({ public: true }).select('uuid', 'username', 'avatar_url')
+const getAllPublic = () => db('users').where({ public: true }).select('uuid', 'username')
 
 const create = async (user) => {
   const inserted = await db('users').insert(user)

--- a/api/routes/authentication.router.js
+++ b/api/routes/authentication.router.js
@@ -28,7 +28,6 @@ const generateToken = require('../utils/generateToken')
  *        - username
  *        - email
  *        - password
- *        - avatar_url
  *      properties:
  *        username:
  *          type: string
@@ -36,16 +35,11 @@ const generateToken = require('../utils/generateToken')
  *          type: string
  *        password:
  *          type: string
- *        avatar_url:
- *          type: string
- *          description: public url of user avatar
  *      example:
  *        uuid: '7a97e42c-124c-4e2c-8109-c5ce6e5f77a4'
  *        username: 'The_Riker'
  *        email: 'william.t.riker@starfleet.com'
  *        password: '@R33allyG00dP@55w0rd'
- *        avatar_url:
- *          'https://upload.wikimedia.org/wikipedia/en/thumb/2/20/WilRiker.jpg/220px-WilRiker.jpg'
  *
  * /auth/register:
  *  post:

--- a/api/routes/profiles.router.js
+++ b/api/routes/profiles.router.js
@@ -13,13 +13,9 @@ const { verifyProfile } = require('../middleware/profiles.middleware')
  *          type: string
  *        uuid:
  *          type: string
- *        avatar_url:
- *          type: string
- *          format: url
  *      example:
  *        username: The_Riker
  *        uuid: 7a97e42c-124c-4e2c-8109-c5ce6e5f77a4
- *        avatar_url: https://upload.wikimedia.org/wikipedia/en/thumb/2/20/WilRiker.jpg/220px-WilRiker.jpg
  *
  * /profiles:
  *   get:

--- a/data/migrations/20210206132920_users_tbl_drop_avatar_url_clmn.js
+++ b/data/migrations/20210206132920_users_tbl_drop_avatar_url_clmn.js
@@ -1,0 +1,9 @@
+exports.up = (knex) =>
+  knex.schema.alterTable('users', (table) => {
+    table.dropColumn('avatar_url')
+  })
+
+exports.down = (knex) =>
+  knex.schema.alterTable('users', (table) => {
+    table.string('avatar_url').notNullable()
+  })

--- a/data/seeds/001-users.js
+++ b/data/seeds/001-users.js
@@ -17,25 +17,19 @@ exports.seed = (knex) =>
           uuid: '1d9dd170-8757-40ec-9ccf-11e4e3de27b1',
           username: 'Jean-Luck',
           email: 'jean-luc.picard@starfleet.com',
-          password: hashOne,
-          avatar_url:
-            'https://upload.wikimedia.org/wikipedia/en/8/8e/Patrick_Steward_as_Jean-Luc_Picard_in_1996%27s_Star_Trek_First_Contact.jpg'
+          password: hashOne
         },
         {
           uuid: '7a97e42c-124c-4e2c-8109-c5ce6e5f77a4',
           username: 'The_Riker',
           email: 'william.t.riker@starfleet.com',
-          password: hashTwo,
-          avatar_url:
-            'https://upload.wikimedia.org/wikipedia/en/thumb/2/20/WilRiker.jpg/220px-WilRiker.jpg'
+          password: hashTwo
         },
         {
           uuid: '1e4d861c-d301-4318-9fd6-96ccbec9f821',
           username: 'CMDR_Data',
           email: 'data.soong@starfleet.com',
           password: hashThree,
-          avatar_url:
-            'https://upload.wikimedia.org/wikipedia/en/thumb/0/09/DataTNG.jpg/220px-DataTNG.jpg',
           public: false
         }
       ])


### PR DESCRIPTION
This drops the avatar URL column from the 'users' table. I am doing this because as it is right now for a user to register in a front end they will need to be uploading the image with registration which is an undesirable user experience and has made me realize I should handle images uploading to Cloudinary in the backend as well. 

This removes the feature of users having an avatar image. My proposed fix for this is I will create a pull request to add Cloudinary and set up endpoints to upload user avatar image to Cloudinary and then store the URL for the uploaded avatar in an avatars table.